### PR TITLE
Add comprehensive test suite for arxiv_summarization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,11 @@ submit:
 test-local:
 	python test_main_local.py
 
+# 🔹 pytest でのテスト実行
+test:
+	pytest -v
+
+# 🔹 テスト用の依存関係をインストール
+install-test:
+	uv pip install -e ".[test]" --system
+

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,56 @@
+import pytest
+import os
+from unittest.mock import patch
+
+
+@pytest.fixture(autouse=True)
+def mock_environment_variables():
+    """Mock environment variables for all tests"""
+    env_vars = {
+        'SLACK_SIGNING_SECRET': 'test_slack_signing_secret',
+        'SLACK_BOT_TOKEN': 'xoxb-test-slack-bot-token',
+        'OPENAI_API_KEY': 'sk-test-openai-api-key'
+    }
+    
+    with patch.dict(os.environ, env_vars):
+        yield
+
+
+@pytest.fixture
+def sample_arxiv_xml():
+    """Sample arXiv API XML response for testing"""
+    return '''<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <entry>
+        <title>Attention Is All You Need</title>
+        <summary>The dominant sequence transduction models are based on complex recurrent or convolutional neural networks that include an encoder and a decoder. The best performing models also connect the encoder and decoder through an attention mechanism. We propose a new simple network architecture, the Transformer, based solely on attention mechanisms, dispensing with recurrence and convolutions entirely.</summary>
+    </entry>
+</feed>'''
+
+
+@pytest.fixture
+def sample_slack_event():
+    """Sample Slack event payload for testing"""
+    return {
+        "event": {
+            "type": "app_mention",
+            "channel": "C1234567890",
+            "text": "<@U123456789> https://arxiv.org/abs/1706.03762",
+            "ts": "1234567890.123456",
+            "user": "U123456789"
+        },
+        "type": "event_callback",
+        "team_id": "T1234567890",
+        "api_app_id": "A1234567890"
+    }
+
+
+@pytest.fixture
+def sample_openai_response():
+    """Sample OpenAI API response structure"""
+    from handler import Result
+    return Result(
+        problem="既存のシーケンス変換モデルは複雑なRNNやCNNに依存しており、並列化が困難で計算効率が悪いという課題がある。",
+        contribution="注意機構のみに基づく新しいTransformerアーキテクチャを提案し、RNNやCNNを完全に排除することで、並列化可能で効率的なモデルを実現した。",
+        conclusion="Transformerは翻訳タスクにおいて既存モデルを上回る性能を示し、訓練時間も大幅に短縮された。注意機構のみでシーケンス変換が可能であることを実証した。"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,11 @@ dependencies = [
     "slack-sdk>=3.35.0",
     "uvicorn>=0.34.2",
 ]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+    "pytest-mock>=3.12.0",
+    "httpx>=0.25.0",
+]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+pytest>=8.0.0
+pytest-asyncio>=0.23.0
+pytest-mock>=3.12.0
+httpx>=0.25.0

--- a/test_handler.py
+++ b/test_handler.py
@@ -1,0 +1,192 @@
+import pytest
+import re
+from unittest.mock import patch, MagicMock
+from handler import (
+    fetch_arxiv_info, 
+    summarize, 
+    handle_arxiv_request, 
+    arxiv_pattern,
+    Result
+)
+
+
+class TestArxivPattern:
+    """Test the arXiv URL pattern matching"""
+    
+    def test_arxiv_pattern_basic_url(self):
+        url = "https://arxiv.org/abs/2404.07979"
+        match = re.search(arxiv_pattern, url)
+        assert match is not None
+        assert match.group(1) == "2404.07979"
+    
+    def test_arxiv_pattern_with_version(self):
+        url = "https://arxiv.org/abs/2404.07979v1"
+        match = re.search(arxiv_pattern, url)
+        assert match is not None
+        assert match.group(1) == "2404.07979"
+    
+    def test_arxiv_pattern_www_prefix(self):
+        url = "https://www.arxiv.org/abs/2404.07979"
+        match = re.search(arxiv_pattern, url)
+        assert match is not None
+        assert match.group(1) == "2404.07979"
+    
+    def test_arxiv_pattern_http(self):
+        url = "http://arxiv.org/abs/2404.07979"
+        match = re.search(arxiv_pattern, url)
+        assert match is not None
+        assert match.group(1) == "2404.07979"
+    
+    def test_arxiv_pattern_invalid_url(self):
+        url = "https://google.com/abs/2404.07979"
+        match = re.search(arxiv_pattern, url)
+        assert match is None
+    
+    def test_arxiv_pattern_invalid_id_format(self):
+        url = "https://arxiv.org/abs/invalid"
+        match = re.search(arxiv_pattern, url)
+        assert match is None
+
+
+class TestFetchArxivInfo:
+    """Test the arXiv API fetch functionality"""
+    
+    @patch('handler.requests.get')
+    def test_fetch_arxiv_info_success(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = '''<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <entry>
+        <title>Test Paper Title</title>
+        <summary>This is a test abstract for the paper.</summary>
+    </entry>
+</feed>'''
+        mock_get.return_value = mock_response
+        
+        title, abstract = fetch_arxiv_info("2404.07979")
+        
+        assert title == "Test Paper Title"
+        assert abstract == "This is a test abstract for the paper."
+        mock_get.assert_called_once_with("http://export.arxiv.org/api/query?id_list=2404.07979")
+    
+    @patch('handler.requests.get')
+    def test_fetch_arxiv_info_http_error(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_get.return_value = mock_response
+        
+        title, abstract = fetch_arxiv_info("invalid.id")
+        
+        assert title is None
+        assert abstract is None
+    
+    @patch('handler.requests.get')
+    def test_fetch_arxiv_info_empty_response(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = '''<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+</feed>'''
+        mock_get.return_value = mock_response
+        
+        title, abstract = fetch_arxiv_info("2404.07979")
+        
+        assert title == ""
+        assert abstract == ""
+
+
+class TestSummarize:
+    """Test the OpenAI summarization functionality"""
+    
+    @patch('handler.oai_clinet.beta.chat.completions.parse')
+    def test_summarize_success(self, mock_parse):
+        mock_result = Result(
+            problem="Test problem description",
+            contribution="Test contribution description", 
+            conclusion="Test conclusion description"
+        )
+        mock_response = MagicMock()
+        mock_response.choices[0].message.parsed = mock_result
+        mock_parse.return_value = mock_response
+        
+        title = "Test Paper Title"
+        abstract = "Test abstract content"
+        
+        result = summarize(title, abstract)
+        
+        expected = "*タイトル* :Test Paper Title\n*課題* ：Test problem description\n*貢献* :Test contribution description\n*結論* :Test conclusion description"
+        assert result == expected
+        
+        mock_parse.assert_called_once()
+        call_args = mock_parse.call_args
+        assert call_args[1]['model'] == "gpt-4o"
+        assert call_args[1]['response_format'] == Result
+        assert len(call_args[1]['messages']) == 2
+        assert "タイトル: Test Paper Title" in call_args[1]['messages'][1]['content']
+        assert "概要: Test abstract content" in call_args[1]['messages'][1]['content']
+
+
+class TestHandleArxivRequest:
+    """Test the main request handling function"""
+    
+    @patch('handler.fetch_arxiv_info')
+    @patch('handler.summarize')
+    def test_handle_arxiv_request_success(self, mock_summarize, mock_fetch):
+        mock_fetch.return_value = ("Test Title", "Test Abstract")
+        mock_summarize.return_value = "Test Summary"
+        
+        text = "Check out this paper: https://arxiv.org/abs/2404.07979"
+        result = handle_arxiv_request(text)
+        
+        assert result == "Test Summary"
+        mock_fetch.assert_called_once_with("2404.07979")
+        mock_summarize.assert_called_once_with("Test Title", "Test Abstract")
+    
+    @patch('handler.fetch_arxiv_info')
+    def test_handle_arxiv_request_fetch_failure(self, mock_fetch):
+        mock_fetch.return_value = (None, None)
+        
+        text = "Check out this paper: https://arxiv.org/abs/2404.07979"
+        result = handle_arxiv_request(text)
+        
+        assert result == "arXivから情報を取得できませんでした。"
+    
+    def test_handle_arxiv_request_no_url(self):
+        text = "This text has no arXiv URL"
+        result = handle_arxiv_request(text)
+        
+        expected = ("フォーマットが正しくありません。\n"
+                   "`https://arxiv.org/abs/XXXX.XXXXX` という形式で送信してください。")
+        assert result == expected
+    
+    def test_handle_arxiv_request_invalid_url(self):
+        text = "Check out https://google.com instead"
+        result = handle_arxiv_request(text)
+        
+        expected = ("フォーマットが正しくありません。\n"
+                   "`https://arxiv.org/abs/XXXX.XXXXX` という形式で送信してください。")
+        assert result == expected
+
+
+class TestResultModel:
+    """Test the Pydantic Result model"""
+    
+    def test_result_model_creation(self):
+        result = Result(
+            problem="Test problem",
+            contribution="Test contribution",
+            conclusion="Test conclusion"
+        )
+        
+        assert result.problem == "Test problem"
+        assert result.contribution == "Test contribution"
+        assert result.conclusion == "Test conclusion"
+    
+    def test_result_model_validation(self):
+        with pytest.raises(ValueError):
+            Result(
+                problem="Test problem",
+                contribution="Test contribution"
+                # Missing conclusion
+            )

--- a/test_integration.py
+++ b/test_integration.py
@@ -1,0 +1,164 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from handler import handle_arxiv_request, fetch_arxiv_info, Result
+
+
+class TestEndToEndIntegration:
+    """End-to-end integration tests that simulate real workflows"""
+    
+    @patch('handler.oai_clinet.beta.chat.completions.parse')
+    @patch('handler.requests.get')
+    def test_complete_arxiv_processing_flow(self, mock_requests, mock_openai):
+        """Test the complete flow from arXiv URL to summary"""
+        
+        # Mock arXiv API response
+        mock_arxiv_response = MagicMock()
+        mock_arxiv_response.status_code = 200
+        mock_arxiv_response.text = '''<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <entry>
+        <title>Attention Is All You Need</title>
+        <summary>The dominant sequence transduction models are based on complex recurrent or convolutional neural networks that include an encoder and a decoder. The best performing models also connect the encoder and decoder through an attention mechanism. We propose a new simple network architecture, the Transformer, based solely on attention mechanisms, dispensing with recurrence and convolutions entirely.</summary>
+    </entry>
+</feed>'''
+        mock_requests.return_value = mock_arxiv_response
+        
+        # Mock OpenAI response
+        mock_result = Result(
+            problem="既存のシーケンス変換モデルは複雑なRNNやCNNに依存しており、並列化が困難で計算効率が悪いという課題がある。",
+            contribution="注意機構のみに基づく新しいTransformerアーキテクチャを提案し、RNNやCNNを完全に排除することで、並列化可能で効率的なモデルを実現した。",
+            conclusion="Transformerは翻訳タスクにおいて既存モデルを上回る性能を示し、訓練時間も大幅に短縮された。注意機構のみでシーケンス変換が可能であることを実証した。"
+        )
+        mock_openai_response = MagicMock()
+        mock_openai_response.choices[0].message.parsed = mock_result
+        mock_openai.return_value = mock_openai_response
+        
+        # Test the complete flow
+        text = "Please summarize: https://arxiv.org/abs/1706.03762"
+        result = handle_arxiv_request(text)
+        
+        # Verify the result format
+        assert "*タイトル* :Attention Is All You Need" in result
+        assert "*課題* ：既存のシーケンス変換モデルは複雑な" in result
+        assert "*貢献* :注意機構のみに基づく新しい" in result
+        assert "*結論* :Transformerは翻訳タスクにおいて" in result
+        
+        # Verify API calls
+        mock_requests.assert_called_once_with("http://export.arxiv.org/api/query?id_list=1706.03762")
+        mock_openai.assert_called_once()
+    
+    @patch('handler.requests.get')
+    def test_arxiv_api_failure_handling(self, mock_requests):
+        """Test handling of arXiv API failures"""
+        
+        # Mock failed arXiv API response
+        mock_arxiv_response = MagicMock()
+        mock_arxiv_response.status_code = 404
+        mock_requests.return_value = mock_arxiv_response
+        
+        text = "Please summarize: https://arxiv.org/abs/9999.99999"
+        result = handle_arxiv_request(text)
+        
+        assert result == "arXivから情報を取得できませんでした。"
+    
+    def test_invalid_url_formats(self):
+        """Test various invalid URL formats"""
+        
+        test_cases = [
+            "No URL here",
+            "https://google.com/search?q=test",
+            "arxiv.org/abs/1234.5678",  # Missing protocol
+            "https://arxiv.org/abs/invalid-format",
+            "https://arxiv.org/paper/1234.5678",  # Wrong path
+        ]
+        
+        expected_error = ("フォーマットが正しくありません。\n"
+                         "`https://arxiv.org/abs/XXXX.XXXXX` という形式で送信してください。")
+        
+        for test_text in test_cases:
+            result = handle_arxiv_request(test_text)
+            assert result == expected_error
+    
+    def test_url_extraction_from_various_contexts(self):
+        """Test URL extraction from different text contexts"""
+        
+        valid_contexts = [
+            "Check this out: https://arxiv.org/abs/2404.07979",
+            "https://arxiv.org/abs/2404.07979 looks interesting",
+            "Paper at https://arxiv.org/abs/2404.07979v1 is good",
+            "See: https://www.arxiv.org/abs/2404.07979",
+            "HTTP link: http://arxiv.org/abs/2404.07979",
+            "Multiple links: https://google.com and https://arxiv.org/abs/2404.07979",
+        ]
+        
+        with patch('handler.fetch_arxiv_info') as mock_fetch:
+            mock_fetch.return_value = (None, None)  # Simulate fetch failure
+            
+            for context in valid_contexts:
+                result = handle_arxiv_request(context)
+                # Should attempt to fetch, not return format error
+                assert result == "arXivから情報を取得できませんでした。"
+                mock_fetch.assert_called_with("2404.07979")
+                mock_fetch.reset_mock()
+
+
+class TestErrorHandling:
+    """Test error handling scenarios"""
+    
+    @patch('handler.oai_clinet.beta.chat.completions.parse')
+    def test_openai_api_error(self, mock_openai):
+        """Test handling of OpenAI API errors"""
+        
+        # Mock OpenAI API failure
+        mock_openai.side_effect = Exception("API Error")
+        
+        with patch('handler.fetch_arxiv_info') as mock_fetch:
+            mock_fetch.return_value = ("Test Title", "Test Abstract")
+            
+            # Should raise the exception
+            with pytest.raises(Exception):
+                handle_arxiv_request("https://arxiv.org/abs/2404.07979")
+    
+    @patch('handler.requests.get')
+    def test_malformed_xml_response(self, mock_requests):
+        """Test handling of malformed XML from arXiv API"""
+        
+        # Mock malformed XML response
+        mock_arxiv_response = MagicMock()
+        mock_arxiv_response.status_code = 200
+        mock_arxiv_response.text = "Invalid XML content"
+        mock_requests.return_value = mock_arxiv_response
+        
+        title, abstract = fetch_arxiv_info("2404.07979")
+        
+        # Should handle XML parsing error gracefully
+        assert title == ""
+        assert abstract == ""
+
+
+class TestPerformance:
+    """Performance and edge case tests"""
+    
+    def test_very_long_text_with_url(self):
+        """Test handling of very long text containing arXiv URL"""
+        
+        long_text = "Lorem ipsum " * 1000 + " https://arxiv.org/abs/2404.07979 " + "dolor sit amet " * 1000
+        
+        with patch('handler.fetch_arxiv_info') as mock_fetch:
+            mock_fetch.return_value = (None, None)
+            
+            result = handle_arxiv_request(long_text)
+            assert result == "arXivから情報を取得できませんでした。"
+            mock_fetch.assert_called_once_with("2404.07979")
+    
+    def test_multiple_arxiv_urls(self):
+        """Test text with multiple arXiv URLs (should process first one)"""
+        
+        text = "First: https://arxiv.org/abs/2404.07979 Second: https://arxiv.org/abs/1706.03762"
+        
+        with patch('handler.fetch_arxiv_info') as mock_fetch:
+            mock_fetch.return_value = (None, None)
+            
+            result = handle_arxiv_request(text)
+            # Should process the first URL found
+            mock_fetch.assert_called_once_with("2404.07979")

--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,285 @@
+import pytest
+import json
+import time
+import hmac
+import hashlib
+from unittest.mock import patch, MagicMock, AsyncMock
+from fastapi.testclient import TestClient
+from main import app, verify_slack_request
+
+
+class TestVerifySlackRequest:
+    """Test Slack request verification functionality"""
+    
+    def test_verify_slack_request_valid(self):
+        # Setup
+        signing_secret = "test_secret"
+        timestamp = str(int(time.time()))
+        body = "test_body"
+        
+        # Create valid signature
+        sig_basestring = f"v0:{timestamp}:{body}".encode("utf-8")
+        computed_signature = "v0=" + hmac.new(
+            signing_secret.encode("utf-8"),
+            sig_basestring,
+            hashlib.sha256
+        ).hexdigest()
+        
+        headers = {
+            "x-slack-request-timestamp": timestamp,
+            "x-slack-signature": computed_signature
+        }
+        
+        with patch('main.SLACK_SIGNING_SECRET', signing_secret):
+            result = verify_slack_request(headers, body)
+            assert result is True
+    
+    def test_verify_slack_request_missing_timestamp(self):
+        headers = {
+            "x-slack-signature": "v0=test_signature"
+        }
+        result = verify_slack_request(headers, "test_body")
+        assert result is False
+    
+    def test_verify_slack_request_missing_signature(self):
+        headers = {
+            "x-slack-request-timestamp": str(int(time.time()))
+        }
+        result = verify_slack_request(headers, "test_body")
+        assert result is False
+    
+    def test_verify_slack_request_expired_timestamp(self):
+        # Timestamp older than 5 minutes
+        old_timestamp = str(int(time.time()) - 400)
+        headers = {
+            "x-slack-request-timestamp": old_timestamp,
+            "x-slack-signature": "v0=test_signature"
+        }
+        result = verify_slack_request(headers, "test_body")
+        assert result is False
+    
+    def test_verify_slack_request_invalid_signature(self):
+        timestamp = str(int(time.time()))
+        headers = {
+            "x-slack-request-timestamp": timestamp,
+            "x-slack-signature": "v0=invalid_signature"
+        }
+        
+        with patch('main.SLACK_SIGNING_SECRET', "test_secret"):
+            result = verify_slack_request(headers, "test_body")
+            assert result is False
+
+
+class TestSlackWebhook:
+    """Test the main Slack webhook endpoint"""
+    
+    def setup_method(self):
+        self.client = TestClient(app)
+    
+    @patch('main.verify_slack_request')
+    def test_unauthorized_request(self, mock_verify):
+        mock_verify.return_value = False
+        
+        response = self.client.post("/", content="test_body")
+        
+        assert response.status_code == 401
+        assert response.json() == {"error": "unauthorized"}
+    
+    @patch('main.verify_slack_request')
+    def test_url_verification_challenge(self, mock_verify):
+        mock_verify.return_value = True
+        
+        challenge_payload = {
+            "type": "url_verification",
+            "challenge": "test_challenge_token"
+        }
+        
+        response = self.client.post("/", json=challenge_payload)
+        
+        assert response.status_code == 200
+        assert response.json() == {"challenge": "test_challenge_token"}
+    
+    @patch('main.verify_slack_request')
+    def test_retry_request_ignored(self, mock_verify):
+        mock_verify.return_value = True
+        
+        headers = {"x-slack-retry-num": "1"}
+        response = self.client.post("/", json={}, headers=headers)
+        
+        assert response.status_code == 200
+        assert response.json() == {"message": "Retry ignored"}
+    
+    @patch('main.verify_slack_request')
+    def test_non_app_mention_event(self, mock_verify):
+        mock_verify.return_value = True
+        
+        event_payload = {
+            "event": {
+                "type": "message",
+                "text": "regular message"
+            }
+        }
+        
+        response = self.client.post("/", json=event_payload)
+        
+        assert response.status_code == 200
+        assert response.json() == {"message": "No action taken"}
+    
+    @patch('main.verify_slack_request')
+    def test_missing_event(self, mock_verify):
+        mock_verify.return_value = True
+        
+        payload = {"not_event": "data"}
+        
+        response = self.client.post("/", json=payload)
+        
+        assert response.status_code == 200
+        assert response.json() == {"message": "No action taken"}
+    
+    @patch('main.client.chat_postMessage')
+    @patch('main.handle_arxiv_request')
+    @patch('main.verify_slack_request')
+    def test_successful_app_mention(self, mock_verify, mock_handle, mock_post_message):
+        mock_verify.return_value = True
+        mock_handle.return_value = "Test response from handler"
+        mock_post_message.return_value = None
+        
+        event_payload = {
+            "event": {
+                "type": "app_mention",
+                "channel": "C1234567890",
+                "text": "<@U123456789> https://arxiv.org/abs/2404.07979",
+                "ts": "1234567890.123456"
+            }
+        }
+        
+        response = self.client.post("/", json=event_payload)
+        
+        assert response.status_code == 200
+        assert response.json() == {"message": "Processed"}
+        
+        mock_handle.assert_called_once_with("<@U123456789> https://arxiv.org/abs/2404.07979")
+        mock_post_message.assert_called_once_with(
+            channel="C1234567890",
+            text="Test response from handler",
+            thread_ts="1234567890.123456",
+            reply_broadcast=True
+        )
+    
+    @patch('main.client.chat_postMessage')
+    @patch('main.handle_arxiv_request')
+    @patch('main.verify_slack_request')
+    def test_slack_api_error_handling(self, mock_verify, mock_handle, mock_post_message):
+        from slack_sdk.errors import SlackApiError
+        
+        mock_verify.return_value = True
+        mock_handle.return_value = "Test response"
+        mock_post_message.side_effect = SlackApiError("API Error", response=MagicMock())
+        
+        event_payload = {
+            "event": {
+                "type": "app_mention",
+                "channel": "C1234567890",
+                "text": "test message",
+                "ts": "1234567890.123456"
+            }
+        }
+        
+        # Should not raise exception and return success
+        response = self.client.post("/", json=event_payload)
+        
+        assert response.status_code == 200
+        assert response.json() == {"message": "Processed"}
+    
+    @patch('main.client.chat_postMessage')
+    @patch('main.handle_arxiv_request')
+    @patch('main.verify_slack_request')
+    def test_app_mention_without_text(self, mock_verify, mock_handle, mock_post_message):
+        mock_verify.return_value = True
+        mock_handle.return_value = "Handler response"
+        mock_post_message.return_value = None
+        
+        event_payload = {
+            "event": {
+                "type": "app_mention",
+                "channel": "C1234567890",
+                "ts": "1234567890.123456"
+                # No "text" field
+            }
+        }
+        
+        response = self.client.post("/", json=event_payload)
+        
+        assert response.status_code == 200
+        assert response.json() == {"message": "Processed"}
+        
+        # Should pass empty string when text is missing
+        mock_handle.assert_called_once_with("")
+
+
+class TestAppConfiguration:
+    """Test application configuration and setup"""
+    
+    @patch.dict('os.environ', {
+        'SLACK_SIGNING_SECRET': 'test_secret',
+        'SLACK_BOT_TOKEN': 'test_token'
+    })
+    def test_environment_variables_loaded(self):
+        # Reload main module to test environment variable loading
+        import importlib
+        import main
+        importlib.reload(main)
+        
+        assert main.SLACK_SIGNING_SECRET == 'test_secret'
+        assert main.SLACK_BOT_TOKEN == 'test_token'
+    
+    def test_fastapi_app_creation(self):
+        assert app is not None
+        assert hasattr(app, 'post')
+
+
+class TestIntegration:
+    """Integration tests combining multiple components"""
+    
+    def setup_method(self):
+        self.client = TestClient(app)
+    
+    @patch('main.handle_arxiv_request')
+    @patch('main.client.chat_postMessage')
+    def test_full_workflow_with_valid_arxiv_url(self, mock_post_message, mock_handle):
+        mock_handle.return_value = "Successfully processed arXiv paper"
+        mock_post_message.return_value = None
+        
+        # Create valid request
+        timestamp = str(int(time.time()))
+        body_data = {
+            "event": {
+                "type": "app_mention",
+                "channel": "C1234567890",
+                "text": "<@U123456789> https://arxiv.org/abs/2404.07979",
+                "ts": "1234567890.123456"
+            }
+        }
+        body = json.dumps(body_data)
+        
+        # Create valid signature
+        with patch('main.SLACK_SIGNING_SECRET', 'test_secret'):
+            sig_basestring = f"v0:{timestamp}:{body}".encode("utf-8")
+            computed_signature = "v0=" + hmac.new(
+                'test_secret'.encode("utf-8"),
+                sig_basestring,
+                hashlib.sha256
+            ).hexdigest()
+        
+            headers = {
+                "x-slack-request-timestamp": timestamp,
+                "x-slack-signature": computed_signature,
+                "content-type": "application/json"
+            }
+        
+            response = self.client.post("/", content=body, headers=headers)
+        
+            assert response.status_code == 200
+            assert response.json() == {"message": "Processed"}
+            mock_handle.assert_called_once()
+            mock_post_message.assert_called_once()


### PR DESCRIPTION
Fixes #3

Adds a complete pytest-based test suite covering:
- Unit tests for arXiv processing and OpenAI integration
- FastAPI endpoint tests with Slack webhook verification
- Integration and end-to-end workflow tests
- Error handling and edge case coverage
- Test infrastructure with proper mocking and fixtures

Generated with [Claude Code](https://claude.ai/code)