### PR TITLE
fix: update Docker base image to Python 3.11-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # arxiv_slack_bot/Dockerfile
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 # 環境変数設定
 ENV PORT=8080


### PR DESCRIPTION
Resolves Cloud Build error where Python 3.10.17 was incompatible with package requirement of >=3.11.

Closes #9

Generated with [Claude Code](https://claude.ai/code)