### PR TITLE
feat: split Slack posts into two separate messages

### DIFF
--- a/src/arxiv_slack_bot/handler.py
+++ b/src/arxiv_slack_bot/handler.py
@@ -57,7 +57,13 @@ def summarize(title, abstract):
     )
     resp = ret.choices[0].message.parsed
 
-    return f"*タイトル* :{title}\n*概要* :{resp.overview}\n*課題* :{resp.problem}\n*貢献* :{resp.contribution}\n*結論* :{resp.conclusion}"
+    # 1つ目の投稿: タイトル・課題・貢献・結論
+    first_post = f"*タイトル* :{title}\n*課題* :{resp.problem}\n*貢献* :{resp.contribution}\n*結論* :{resp.conclusion}"
+    
+    # 2つ目の投稿: 概要
+    second_post = f"*概要* :{resp.overview}"
+    
+    return first_post, second_post
 
 
 def handle_arxiv_request(text):
@@ -68,9 +74,9 @@ def handle_arxiv_request(text):
         if title and abstract:
             return summarize(title, abstract)
         else:
-            return "arXivから情報を取得できませんでした。"
+            return "arXivから情報を取得できませんでした。", None
     else:
         return (
             "フォーマットが正しくありません。\n"
             "`https://arxiv.org/abs/XXXX.XXXXX` という形式で送信してください。"
-        )
+        ), None

--- a/src/arxiv_slack_bot/main.py
+++ b/src/arxiv_slack_bot/main.py
@@ -63,15 +63,25 @@ async def slack_webhook(request: Request):
     thread_ts = slack_event["event"].get("ts")
     print(channel, text, thread_ts)
 
-    response_text = handle_arxiv_request(text)
+    first_post, second_post = handle_arxiv_request(text)
 
     try:
+        # 1つ目の投稿: タイトル・課題・貢献・結論
         client.chat_postMessage(
             channel=channel,
-            text=response_text,
+            text=first_post,
             thread_ts=thread_ts,
             reply_broadcast=True
         )
+        
+        # 2つ目の投稿: 概要（second_postがNoneでない場合のみ）
+        if second_post:
+            client.chat_postMessage(
+                channel=channel,
+                text=second_post,
+                thread_ts=thread_ts,
+                reply_broadcast=True
+            )
     except SlackApiError as e:
         print(f"Slack API error: {e}")
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -3,7 +3,10 @@ from src.arxiv_slack_bot.handler import handle_arxiv_request
 
 if __name__ == "__main__":
     test_text = "https://arxiv.org/abs/2404.07979"
-    result = handle_arxiv_request(test_text)
+    first_post, second_post = handle_arxiv_request(test_text)
 
-    print("\n--- 要約結果 ---\n")
-    print(result)
+    print("\n--- 要約結果（分割版） ---\n")
+    print("=== 1つ目の投稿 ===")
+    print(first_post)
+    print("\n=== 2つ目の投稿 ===")
+    print(second_post)


### PR DESCRIPTION
Fixes #11

Slack投稿を2つに分割する機能を実装しました。

- 第1の投稿: タイトル・課題・貢献・結論
- 第2の投稿: 概要

Generated with [Claude Code](https://claude.ai/code)